### PR TITLE
9-create text input component

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Text } from "./Text";
+import React from "react";
+
+
+const variants = ["outline", "filled"] as const;
+const sizes = ["lg", "md", "sm"] as const;
+
+/** Define the control fields for Storybook */
+const meta: Meta<typeof Text> = {
+  component: Text,
+  title: "Components/Text",
+  argTypes: {
+    variant: {
+      control: "select",
+      options: variants,
+    },
+    size: {
+      control: "select",
+      options: sizes,
+    }
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Text>;
+
+/** Story for Default Variant */
+export const Default: Story = {
+  args: {
+    size: "md",
+    variant: "outline",
+  },
+};
+
+

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Text } from "./Text";
-import React from "react";
-
 
 const variants = ["outline", "filled"] as const;
 const sizes = ["lg", "md", "sm"] as const;
@@ -18,19 +16,25 @@ const meta: Meta<typeof Text> = {
     size: {
       control: "select",
       options: sizes,
-    }
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Text>;
 
-/** Story for Default Variant */
-export const Default: Story = {
+/** Story for Outline Variant */
+export const Outline: Story = {
   args: {
     size: "md",
     variant: "outline",
   },
 };
 
-
+/** Story for Filled Variant */
+export const Filled: Story = {
+  args: {
+    size: "md", 
+    variant: "filled",
+  },
+};

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { TextProps, textVariants } from "./textVariants";
 
 /**
@@ -13,7 +13,7 @@ export const Text = (props: TextProps) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
 
-    // for external features
+    // for external features based on prop
     if (props.onChange) {
       props.onChange(event);
     }

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from "react";
+import { TextProps, textVariants } from "./textVariants";
+
+/**
+ * Text Input Component
+ *
+ * @param {TextProps} props
+ * @returns Text Input Component
+ */
+export const Text = (props: TextProps) => {
+  const [inputValue, setInputValue] = useState("");
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+
+    // for external features
+    if (props.onChange) {
+      props.onChange(event);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start">
+      {props.label && (
+        <label htmlFor={props.id} className="mb-1">
+          {" "}
+          {props.label}{" "}
+        </label>
+      )}
+      <input
+        type="text"
+        id={props.id}
+        value={inputValue}
+        placeholder={props.placeholder || "Enter text"}
+        onChange={handleChange}
+        className={textVariants(props)}
+      />
+    </div>
+  );
+};

--- a/src/components/Text/textVariants.ts
+++ b/src/components/Text/textVariants.ts
@@ -1,6 +1,7 @@
 import React, { ClassAttributes, InputHTMLAttributes } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
+/** Define Basic Text Variants using Tailwind Variant Definitions */
 export const textVariants = tv({
   base: "rounded px-3 py-2 focus:outline-none focus:ring-2",
   variants: {
@@ -20,17 +21,20 @@ export const textVariants = tv({
   },
 });
 
+/** Create TextProp types for variants */
 export type TextVariants = VariantProps<typeof textVariants>;
 
+/** Utilize HTML Text attributes excluding size and color */
 type HTMLTextProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   "size" | "color"
 > &
   ClassAttributes<HTMLInputElement>;
 
+/** Export the text props as one type */
 export interface TextProps extends TextVariants, HTMLTextProps {
   placeholder?: string;
-  label?: string;
+  label: string;
   id: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/components/Text/textVariants.ts
+++ b/src/components/Text/textVariants.ts
@@ -1,0 +1,36 @@
+import React, { ClassAttributes, InputHTMLAttributes } from "react";
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const textVariants = tv({
+  base: "rounded px-3 py-2 focus:outline-none focus:ring-2",
+  variants: {
+    variant: {
+      outline: "border-2 border-gray-500 focus:bg-grey-200",
+      filled: "bg-black text-white focus:ring-gray focus:bg-whitesmoke",
+    },
+    size: {
+      sm: "text-sm",
+      md: "text-base",
+      lg: "text-lg",
+    },
+  },
+  defaultVariants: {
+    variant: "outline",
+    size: "md",
+  },
+});
+
+export type TextVariants = VariantProps<typeof textVariants>;
+
+type HTMLTextProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size" | "color"
+> &
+  ClassAttributes<HTMLInputElement>;
+
+export interface TextProps extends TextVariants, HTMLTextProps {
+  placeholder?: string;
+  label?: string;
+  id: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}


### PR DESCRIPTION
**Brief Description:**
- Create textVariants.ts: Added two basic variants of text input components - filled and outline with 3 sizes (sm, md, lg) 
- Created Text.tsx: Return the text input component with prop's attributes
    - prop id and label (required)
    - prop placeholder/default value (optional)
    - prop onChange (base effect: updates the current text in the box based on input, other effects based on prop)
- Created Text.stories.tsx: For storybook implementation of basic text input component