### PR TITLE
44 media overlay

### DIFF
--- a/src/design-system/components/MediaOverlay/MediaOverlay.stories.tsx
+++ b/src/design-system/components/MediaOverlay/MediaOverlay.stories.tsx
@@ -3,6 +3,9 @@ import React from "react";
 import { OverlayMedia, Overlay } from "@/components/MediaOverlay";
 import Image from "@/primitives/Image";
 import Icon from "@/primitives/Icon";
+import Badge from "@/primitives/Badge";
+import Box from "@/primitives/Box";
+import Text from "@/primitives/Text";
 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof OverlayMedia> = {
@@ -95,4 +98,77 @@ export const Ratios: Story = {
       ))}
     </div>
   ),
+};
+
+export const Gallery: Story = {
+  render: () => {
+    const overlays = [
+      <Box
+        key="article-cta"
+        className="flex flex-col justify-end h-full p-2 bg-gradient-to-t from-black/80 via-black/40 to-transparent group"
+      >
+        <Text color="white" style="bold" size={16}>
+          New Research Breakthrough
+        </Text>
+        <Box className="flex items-center gap-1">
+          <Text color="white" style="bold" size={14}>
+            Read Now
+          </Text>
+          <Icon
+            icon="arrowright"
+            color="white"
+            size="sm"
+            className="transform transition-transform duration-200 group-hover:translate-x-2"
+          />
+        </Box>
+      </Box>,
+      <Badge key="photographer" color="black" className="absolute bottom-2 right-2 bg-neutral/70" variant="outline">
+        Photographer: Jia^2
+      </Badge>,
+      <Box
+        key="save"
+        className="flex flex-col justify-end h-full p-4 bg-gradient-to-t from-black/80 via-black/40 to-transparent group"
+      >
+        <Box className="flex items-center gap-2 text-sm">
+          <Icon icon="bookmark" color="white" />
+          <Text color="white" style="bold" size={20}>
+            Save
+          </Text>
+        </Box>
+      </Box>,
+      <Badge key="new-issue" color="marigold" className="absolute top-2 left-2">
+        NEW ISSUE
+      </Badge>,
+      <Box key="biology" className="h-full flex items-center justify-center text-center bg-black/70 to-transparent">
+        <Text color="white" style="bold" size={24}>
+          Biology
+        </Text>
+      </Box>,
+      <Box key="progress-bar" className="absolute top-0 left-0 right-0 h-6 bg-neutral/80">
+        <Box className="h-full bg-sage-green text-black text-xs font-bold flex items-center justify-center w-[70%]">70%</Box>
+      </Box>,
+    ];
+
+    const ratios = [1, 4 / 3, 16 / 9, 9 / 16];
+
+    return (
+      <div className="grid grid-cols-3 gap-8">
+        {ratios.map((ratio) =>
+          overlays.map((overlayContent, index) => (
+            <OverlayMedia key={`${ratio}-${index}`}>
+              <Image
+                ratio={ratio}
+                src={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"}
+                alt={`cat ratio ${ratio}`}
+                width="w-[300px]"
+                emphasis="default"
+                rounded="default"
+              />
+              <Overlay>{overlayContent}</Overlay>
+            </OverlayMedia>
+          ))
+        )}
+      </div>
+    );
+  },
 };

--- a/src/design-system/components/MediaOverlay/MediaOverlay.stories.tsx
+++ b/src/design-system/components/MediaOverlay/MediaOverlay.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { OverlayMedia, Overlay } from "@/components/MediaOverlay";
+import Image from "@/primitives/Image";
+import Icon from "@/primitives/Icon";
+
+/** Define the control fields for Storybook */
+const meta: Meta<typeof OverlayMedia> = {
+  component: OverlayMedia,
+  title: "Components/MediaOverlay",
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof OverlayMedia>;
+
+export const Default: Story = {
+  render: () => (
+    <OverlayMedia>
+      <Image
+        ratio={1}
+        src={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"}
+        alt="cat"
+        width="w-[300px]"
+        emphasis="default"
+        rounded="default"
+      />
+      <Overlay>
+        <div className="flex items-center justify-center h-full text-white text-2xl bg-black/50">Overlay Text</div>
+      </Overlay>
+    </OverlayMedia>
+  ),
+};
+
+export const Gradient: Story = {
+  render: () => {
+    const gradients = [
+      "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
+      "bg-gradient-to-t from-aqua/80 via-aqua-light/40 to-transparent",
+      "bg-gradient-to-t from-forest-green/80 via-sage-green/40 to-transparent",
+      "bg-gradient-to-t from-purple/80 via-pink/40 to-transparent",
+      "bg-gradient-to-t from-maroon/80 via-coral/40 to-transparent",
+      "bg-gradient-to-t from-coral/80 via-marigold/40 to-transparent",
+      "bg-gradient-to-t from-neutral/80 via-gray/40 to-transparent",
+    ];
+
+    return (
+      <div className="flex flex-col gap-8">
+        {gradients.map((gradient, index) => (
+          <OverlayMedia key={index}>
+            <Image
+              ratio={1}
+              src={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"}
+              alt="cat"
+              width="w-[300px]"
+              emphasis="default"
+              rounded="default"
+            />
+            <Overlay>
+              <div className={`flex flex-col justify-end h-full p-4 text-white ${gradient}`}>
+                <div className="flex items-center gap-2 text-lg">
+                  <Icon icon="share" color="white" />
+                  <span>Gradient {index + 1}</span>
+                </div>
+              </div>
+            </Overlay>
+          </OverlayMedia>
+        ))}
+      </div>
+    );
+  },
+};
+
+export const Ratios: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      {[1, 3 / 2, 16 / 9, 4 / 3, 9 / 16].map((ratio) => (
+        <OverlayMedia key={ratio}>
+          <Image
+            ratio={ratio}
+            src={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"}
+            alt={`cat ${ratio}`}
+            width="w-[300px]"
+            emphasis="default"
+            rounded="default"
+          />
+          <Overlay>
+            <div className="flex flex-col justify-end h-full p-4 text-white bg-gradient-to-t from-black/90 to-transparent">
+              <div className="flex items-center gap-2 text-lg">
+                <span className="font-bold">Ratio: {ratio}</span>
+              </div>
+            </div>
+          </Overlay>
+        </OverlayMedia>
+      ))}
+    </div>
+  ),
+};

--- a/src/design-system/components/MediaOverlay/MediaOverlay.tsx
+++ b/src/design-system/components/MediaOverlay/MediaOverlay.tsx
@@ -1,6 +1,7 @@
 import { MediaOverlayProps, OverlayProps } from "./variants";
 import React from "react";
 import clsx from "clsx";
+import Box from "@/primitives/Box";
 
 export function Overlay({ children }: OverlayProps) {
   return <div className="absolute inset-0">{children}</div>;
@@ -9,9 +10,9 @@ export function OverlayMedia({ className, onClick, children }: MediaOverlayProps
   const [imageChild, overlayChild] = children;
 
   return (
-    <div className={clsx("relative", className)} onClick={onClick}>
+    <Box className={clsx("relative", className)} onClick={onClick}>
       {imageChild}
       {overlayChild}
-    </div>
+    </Box>
   );
 }

--- a/src/design-system/components/MediaOverlay/MediaOverlay.tsx
+++ b/src/design-system/components/MediaOverlay/MediaOverlay.tsx
@@ -1,0 +1,17 @@
+import { MediaOverlayProps, OverlayProps } from "./variants";
+import React from "react";
+import clsx from "clsx";
+
+export function Overlay({ children }: OverlayProps) {
+  return <div className="absolute inset-0">{children}</div>;
+}
+export function OverlayMedia({ className, onClick, children }: MediaOverlayProps) {
+  const [imageChild, overlayChild] = children;
+
+  return (
+    <div className={clsx("relative", className)} onClick={onClick}>
+      {imageChild}
+      {overlayChild}
+    </div>
+  );
+}

--- a/src/design-system/components/MediaOverlay/index.tsx
+++ b/src/design-system/components/MediaOverlay/index.tsx
@@ -1,0 +1,5 @@
+import { Overlay, OverlayMedia } from "./MediaOverlay";
+import { OverlayProps, MediaOverlayProps } from "./variants";
+
+export { type OverlayProps, type MediaOverlayProps };
+export { Overlay, OverlayMedia };

--- a/src/design-system/components/MediaOverlay/variants.ts
+++ b/src/design-system/components/MediaOverlay/variants.ts
@@ -1,0 +1,29 @@
+import { tv, type VariantProps } from "tailwind-variants";
+import React from "react";
+import { ImageProps } from "@/primitives/Image";
+
+export const overlayVariants = tv({
+  base: "",
+  variants: {},
+  defaultVariants: {},
+});
+
+export interface OverlayProps extends VariantProps<typeof overlayVariants> {
+  children: React.ReactNode;
+}
+
+export const mediaOverlayVariants = tv({
+  base: "",
+  variants: {},
+  defaultVariants: {},
+});
+
+type OverlayElement = React.ReactElement<OverlayProps>;
+type ImageElement = React.ReactElement<ImageProps>;
+export type MediaOverlayChildren = [ImageElement, OverlayElement];
+
+export interface MediaOverlayProps extends VariantProps<typeof mediaOverlayVariants> {
+  className?: string;
+  onClick?: () => void;
+  children: MediaOverlayChildren;
+}

--- a/src/design-system/primitives/Avatar/Avatar.stories.tsx
+++ b/src/design-system/primitives/Avatar/Avatar.stories.tsx
@@ -8,7 +8,7 @@ const sizes = ["sm", "md", "lg"] as const;
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Avatar> = {
   component: Avatar,
-  title: "Components/Avatar",
+  title: "Primitives/Avatar",
   argTypes: {
     size: {
       control: "select",

--- a/src/design-system/primitives/Avatar/Avatar.tsx
+++ b/src/design-system/primitives/Avatar/Avatar.tsx
@@ -7,12 +7,12 @@ import { avatarVariants, AvatarProps } from "./variants";
  * @param { AvatarProps } props
  * @returns Avatar Component
  */
-export const Avatar = (props: AvatarProps) => {
+export const Avatar = ({ size, src, alt, fallback, onClick }: AvatarProps) => {
   return (
-    <RadixAvatar.Root>
-      <RadixAvatar.Image className={avatarVariants(props)} src={props.src} alt={props.alt ?? "an avatar"} />
-      <RadixAvatar.Fallback className={avatarVariants(props)}>
-        {props.fallback.length == 0 ? "NA" : props.fallback.length <= 2 ? props.fallback : props.fallback.substring(0, 2)}
+    <RadixAvatar.Root onClick={onClick}>
+      <RadixAvatar.Image className={avatarVariants({ size })} src={src} alt={alt ?? "an avatar"} />
+      <RadixAvatar.Fallback className={avatarVariants({ size })}>
+        {fallback.length == 0 ? "NA" : fallback.length <= 2 ? fallback : fallback.substring(0, 2)}
       </RadixAvatar.Fallback>
     </RadixAvatar.Root>
   );

--- a/src/design-system/primitives/Avatar/variants.ts
+++ b/src/design-system/primitives/Avatar/variants.ts
@@ -16,7 +16,8 @@ export const avatarVariants = tv({
 });
 
 export interface AvatarProps extends VariantProps<typeof avatarVariants> {
+  onClick?: () => void;
   src?: string;
-  alt?: string; // add default alt text when not given
-  fallback: string; // validate if it's 1-2 characters long in prop
+  alt?: string;
+  fallback: string;
 }

--- a/src/design-system/primitives/Badge/Badge.stories.tsx
+++ b/src/design-system/primitives/Badge/Badge.stories.tsx
@@ -24,7 +24,7 @@ const colors = [
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Badge> = {
   component: Badge,
-  title: "Components/Badge",
+  title: "Primitives/Badge",
   argTypes: {
     variant: {
       control: "select",

--- a/src/design-system/primitives/Badge/Badge.tsx
+++ b/src/design-system/primitives/Badge/Badge.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { BadgeProps, badgeVariants } from "./variants";
 
 /**
@@ -6,6 +7,6 @@ import { BadgeProps, badgeVariants } from "./variants";
  * @param { BadgeProps } props
  * @returns Badge Component
  */
-export const Badge = (props: BadgeProps) => {
-  return <span className={badgeVariants(props)}>{props.children}</span>;
+export const Badge = ({ className, color, variant, children }: BadgeProps) => {
+  return <span className={clsx(badgeVariants({ color, variant }), className)}>{children}</span>;
 };

--- a/src/design-system/primitives/Badge/variants.ts
+++ b/src/design-system/primitives/Badge/variants.ts
@@ -108,5 +108,6 @@ export type BadgeVariants = VariantProps<typeof badgeVariants>;
 
 /** Export ButtonProps as one type */
 export interface BadgeProps extends BadgeVariants {
+  className?: string;
   children: React.ReactNode;
 }

--- a/src/design-system/primitives/Box/Box.stories.tsx
+++ b/src/design-system/primitives/Box/Box.stories.tsx
@@ -25,13 +25,27 @@ const pts = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 64, 72, 96, 1
 const pbs = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 64, 72, 96, 128] as const;
 const prs = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 64, 72, 96, 128] as const;
 const pls = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 64, 72, 96, 128] as const;
-const colors = [ "black", "white", "red", "aqua", "aqua-light", "forest-green", "sage-green", "border",
-  "neutral", "purple", "pink", "maroon", "coral", "marigold"] as const;
+const colors = [
+  "black",
+  "white",
+  "red",
+  "aqua",
+  "aqua-light",
+  "forest-green",
+  "sage-green",
+  "border",
+  "neutral",
+  "purple",
+  "pink",
+  "maroon",
+  "coral",
+  "marigold",
+] as const;
 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Box> = {
   component: Box,
-  title: "Components/Box",
+  title: "Primitives/Box",
   argTypes: {
     position: {
       control: "select",
@@ -43,88 +57,88 @@ const meta: Meta<typeof Box> = {
     },
     width: {
       control: "select",
-      options: widths
+      options: widths,
     },
     height: {
       control: "select",
-      options: heights
+      options: heights,
     },
     top: {
       control: "select",
-      options: tops
+      options: tops,
     },
     bottom: {
       control: "select",
-      options: bottoms
+      options: bottoms,
     },
     left: {
       control: "select",
-      options: lefts
+      options: lefts,
     },
     right: {
       control: "select",
-      options: rights
+      options: rights,
     },
     m: {
       control: "select",
-      options: ms
+      options: ms,
     },
     mx: {
       control: "select",
-      options: mxs
+      options: mxs,
     },
     my: {
       control: "select",
-      options: mys
+      options: mys,
     },
     mt: {
       control: "select",
-      options: mts
+      options: mts,
     },
     mb: {
       control: "select",
-      options: mbs
+      options: mbs,
     },
     mr: {
       control: "select",
-      options: mrs
+      options: mrs,
     },
     ml: {
       control: "select",
-      options: mls
+      options: mls,
     },
     p: {
       control: "select",
-      options: ps
+      options: ps,
     },
     px: {
       control: "select",
-      options: pxs
+      options: pxs,
     },
     py: {
       control: "select",
-      options: pys
+      options: pys,
     },
     pt: {
       control: "select",
-      options: pts
+      options: pts,
     },
     pb: {
       control: "select",
-      options: pbs
+      options: pbs,
     },
     pr: {
       control: "select",
-      options: prs
+      options: prs,
     },
     pl: {
       control: "select",
-      options: pls
+      options: pls,
     },
     color: {
       control: "select",
-      options: colors
-    }
+      options: colors,
+    },
   },
 };
 
@@ -139,8 +153,8 @@ export const Default: Story = {
     width: "full",
     m: 8,
     height: "full",
-    p: 4
-  }
+    p: 4,
+  },
 };
 
 /** Gallery Story for some box variants with ranging background color, width, and height */
@@ -159,7 +173,7 @@ export const Gallery: Story = {
                       {heights.map((height) => (
                         <div key={`${width}-${height}`} className="flex justify-left p-2">
                           <Box height={height} width={width} color={backgroundColor}>
-                          {width} x {height}
+                            {width} x {height}
                           </Box>
                         </div>
                       ))}

--- a/src/design-system/primitives/Box/variants.ts
+++ b/src/design-system/primitives/Box/variants.ts
@@ -440,5 +440,6 @@ type HTMLBoxProps = Omit<HTMLAttributes<HTMLDivElement>, "color">;
 
 /** Export ButtonProps as one type */
 export interface BoxProps extends HTMLBoxProps, BoxVariants {
+  className?: string;
   children: React.ReactNode;
 }

--- a/src/design-system/primitives/Button/Button.stories.tsx
+++ b/src/design-system/primitives/Button/Button.stories.tsx
@@ -25,7 +25,7 @@ const colors = [
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Button> = {
   component: Button,
-  title: "Components/Button",
+  title: "Primitives/Button",
   argTypes: {
     variant: {
       control: "select",

--- a/src/design-system/primitives/Card/Card.stories.tsx
+++ b/src/design-system/primitives/Card/Card.stories.tsx
@@ -45,7 +45,7 @@ const colors = [
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Card> = {
   component: Card,
-  title: "Components/Card",
+  title: "Primitives/Card",
   argTypes: {
     position: {
       control: "select",

--- a/src/design-system/primitives/Grid/Grid.stories.tsx
+++ b/src/design-system/primitives/Grid/Grid.stories.tsx
@@ -9,7 +9,7 @@ const gaps = [0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 64, 72, 96, 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Grid> = {
   component: Grid,
-  title: "Components/Grid",
+  title: "Primitives/Grid",
   argTypes: {
     col: { control: "boolean" },
     row: { control: "boolean" },

--- a/src/design-system/primitives/Icon/Icon.stories.tsx
+++ b/src/design-system/primitives/Icon/Icon.stories.tsx
@@ -3,8 +3,8 @@ import Icon from "./Icon";
 import type { IconProps } from "./variants";
 import React from "react";
 
-const sizes: IconProps["size"] [] = ["xs", "sm", "md", "lg", "xl"];
-const colors: IconProps["color"] [] = [
+const sizes: IconProps["size"][] = ["xs", "sm", "md", "lg", "xl"];
+const colors: IconProps["color"][] = [
   "black",
   "white",
   "red",
@@ -21,39 +21,54 @@ const colors: IconProps["color"] [] = [
   "marigold",
 ];
 
-const icons: IconProps["icon"] [] = ["search", "loader", "share", "arrowright", "arrowleft",
-"bookmark", "user", "ellipsis", "ellipsisv", "image", "instagram", "linkedin", "star", "trash",
-"zoomin","zoomout"];
+const icons: IconProps["icon"][] = [
+  "search",
+  "loader",
+  "share",
+  "arrowright",
+  "arrowleft",
+  "bookmark",
+  "user",
+  "ellipsis",
+  "ellipsisv",
+  "image",
+  "instagram",
+  "linkedin",
+  "star",
+  "trash",
+  "zoomin",
+  "zoomout",
+];
 
 const meta: Meta<typeof Icon> = {
-    component: Icon, 
-    title: "Components/Icon",
-    argTypes: {
-        icon: {
-            control: "select", 
-            options: icons, 
-        }, 
-        size: {
-            control: "select", 
-            options: sizes,
-        },
-        color: {
-            control: "select", 
-            options: colors, 
-        },
+  component: Icon,
+  title: "Primitives/Icon",
+  argTypes: {
+    icon: {
+      control: "select",
+      options: icons,
     },
+    size: {
+      control: "select",
+      options: sizes,
+    },
+    color: {
+      control: "select",
+      options: colors,
+    },
+  },
 };
 
-export default meta; 
+export default meta;
 
 type Story = StoryObj<typeof Icon>;
 
 export const Default: Story = {
-    args: {
-        icon: "search", 
-        color: "black", 
-        size: "md",
-    },
+  args: {
+    icon: "search",
+    color: "black",
+    size: "md",
+  },
 };
 
 export const Color: Story = {
@@ -69,7 +84,7 @@ export const Color: Story = {
   ),
   // default setting, but can changed in the story book
   args: {
-    icon: "share", 
+    icon: "share",
     size: "md",
   },
 };
@@ -101,15 +116,8 @@ export const Gallery: Story = {
             const isWhite = color === "white";
 
             return (
-              <div
-                key={`${icon}-${color}-${size}`}
-                className="flex flex-col items-center text-center"
-              >
-                <div
-                  className={`p-2 rounded ${
-                    isWhite ? "bg-zinc-300" : ""
-                  }`}
-                >
+              <div key={`${icon}-${color}-${size}`} className="flex flex-col items-center text-center">
+                <div className={`p-2 rounded ${isWhite ? "bg-zinc-300" : ""}`}>
                   <Icon icon={icon} color={color} size={size} />
                 </div>
                 <span className="text-[10px] mt-1">
@@ -123,4 +131,3 @@ export const Gallery: Story = {
     </div>
   ),
 };
-

--- a/src/design-system/primitives/Image/Image.stories.tsx
+++ b/src/design-system/primitives/Image/Image.stories.tsx
@@ -7,7 +7,7 @@ const rounded = ["default", "rounded"] as const;
 
 const meta: Meta<typeof Image> = {
   component: Image,
-  title: "Components/Image",
+  title: "Primitives/Image",
   argTypes: {
     emphasis: {
       control: "select",
@@ -77,10 +77,7 @@ export const Gallery: Story = {
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {rounded.map((rounded) =>
             emphasis.map((emphasis) => (
-              <div
-                key={`${rounded}-${emphasis}`}
-                className="flex flex-col gap-2"
-              >
+              <div key={`${rounded}-${emphasis}`} className="flex flex-col gap-2">
                 <Image
                   ratio={1}
                   rounded={rounded}

--- a/src/design-system/primitives/Link/Link.stories.tsx
+++ b/src/design-system/primitives/Link/Link.stories.tsx
@@ -1,14 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Link from "./Link";
 import React from "react";
+import Image from "@/primitives/Image";
+import Text from "@/primitives/Text";
 
-/* Modify this when adding variants to Text */
 const options = [true, false] as const;
 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Link> = {
   component: Link,
-  title: "Components/Link",
+  title: "Primitives/Link",
   argTypes: {},
 };
 
@@ -18,7 +19,11 @@ type Story = StoryObj<typeof Link>;
 /** Story for Default Variant */
 export const Default: Story = {
   args: {
-    children: <p>example text</p>,
+    children: (
+      <Text color="sage-green" style="underline" size={24} className="hover:text-forest-green">
+        example text
+      </Text>
+    ),
     href: "https://www.google.com",
     newWindow: false,
   },
@@ -30,20 +35,17 @@ export const LinkGallery: Story = {
     <div className="flex flex-col gap-16 p-8 bg-white">
       {options.map((option, index) => (
         <Link href={"https://www.google.com"} newWindow={option} key={index}>
-          <p>example text</p>
+          <Text color="sage-green" style="underline" size={24} className="hover:text-forest-green">
+            example text
+          </Text>
         </Link>
       ))}
-      <Link
-        href={
-          "https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"
-        }
-        newWindow={true}
-      >
-        <img
-          src={
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"
-          }
+      <Link href={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"} newWindow={true}>
+        <Image
+          src={"https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/2560px-A-Cat.jpg"}
           alt={"cat"}
+          ratio={1}
+          width={"w-[300px]"}
         />
       </Link>
     </div>

--- a/src/design-system/primitives/Tab/Tab.stories.tsx
+++ b/src/design-system/primitives/Tab/Tab.stories.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 const meta: Meta<typeof Tab> = {
   component: Tab,
-  title: "Components/Tab",
+  title: "Primitives/Tab",
 };
 
 export default meta;

--- a/src/design-system/primitives/Text/Text.stories.tsx
+++ b/src/design-system/primitives/Text/Text.stories.tsx
@@ -25,7 +25,7 @@ const colors = [
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Text> = {
   component: Text,
-  title: "Components/Text",
+  title: "Primitives/Text",
   argTypes: {
     style: {
       control: "select",

--- a/src/design-system/primitives/Toggle/Toggle.stories.tsx
+++ b/src/design-system/primitives/Toggle/Toggle.stories.tsx
@@ -3,10 +3,8 @@ import { Toggle } from "./Toggle";
 import React from "react";
 
 const colors = [
-  "white",
+  //"white", // white exists but doesn't really serve a purpose
   "black",
-  "light-orange",
-  "dark-orange",
   "gray",
   "aqua",
   "aqua-light",
@@ -23,7 +21,7 @@ const colors = [
 
 const meta: Meta<typeof Toggle> = {
   component: Toggle,
-  title: "Components/Toggle",
+  title: "Primitives/Toggle",
   argTypes: {
     color: {
       control: "select",
@@ -51,14 +49,15 @@ export const Gallery: Story = {
   render: () => {
     return (
       <div className="space-y-8">
-        {colors.map((colors) => (
-          <div key={colors} className="space-y-4">
-            <h3 className="text-lg font-semibold capitalize">{colors}</h3>
-            <div className={`flex gap-4 ${colors === 'white' ? 'bg-zinc-400 p-4 rounded-lg w-fit -ml-4' : ''}`}>
-              <Toggle color={colors} defaultChecked />
+        <h3 className="text-lg font-semibold">Toggle Gallery</h3>
+        <div className="grid grid-cols-3 gap-6">
+          {colors.map((color) => (
+            <div key={color} className="flex flex-col items-start gap-2">
+              <span className="text-sm font-medium capitalize">{color}</span>
+              <Toggle color={color} defaultChecked />
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
## Front End Pull Request

[comment]: <> (All sections are required.)

### Brief Summary
[comment]: <> (Put a brief summary of your changes.)
- Added MediaOverlay Component
- It requires two child props, an `Image` and a `Overlay` component. Overlay a component exported by the MediaOverlay module. 

### Questions / Considerations for the Future
[comment]: <> (Note any questions, or things to note that might involve this PR in the future.)
- The order of the children matters -- there must be an Image prop as the first and then an Overlay component. The overlay component can be literally anything you want to overlay onto the image. 
- Once we have a Video Component, perhaps since it's called MediaOverlay and not ImageOverlay, we include the capabilities to overlay onto an video as well, and accept either an Image or a Video as the first child prop.
- This component's position by default is relative. 

### Image of changes
[comment]: <> (Upload at least one image displaying the changes you've made.)
<img width="999" alt="PNG image" src="https://github.com/user-attachments/assets/87a24469-9fd5-44dd-9c59-f8ccff5a3a2a" />


[comment]: <> (Put the ticket # this PR closes.)
Closes #44 
