### PR TITLE
#51 component nav bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-switch": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.11",
-        "@radix-ui/react-select": "^2.2.5",
         "@types/react-router-dom": "^5.3.3",
         "clsx": "^2.1.1",
         "lucide-react": "^0.510.0",
@@ -13463,6 +13463,49 @@
         }
       }
     },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-select": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
+      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/radix-ui/node_modules/@radix-ui/react-switch": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
@@ -13506,49 +13549,6 @@
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-roving-focus": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-select": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
-      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/number": "1.1.0",
-        "@radix-ui/primitive": "1.1.1",
-        "@radix-ui/react-collection": "1.1.2",
-        "@radix-ui/react-compose-refs": "1.1.1",
-        "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.5",
-        "@radix-ui/react-focus-guards": "1.1.1",
-        "@radix-ui/react-focus-scope": "1.1.2",
-        "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-popper": "1.2.2",
-        "@radix-ui/react-portal": "1.1.4",
-        "@radix-ui/react-primitive": "2.0.2",
-        "@radix-ui/react-slot": "1.1.2",
-        "@radix-ui/react-use-callback-ref": "1.1.0",
-        "@radix-ui/react-use-controllable-state": "1.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0",
-        "@radix-ui/react-use-previous": "1.1.0",
-        "@radix-ui/react-visually-hidden": "1.1.2",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/src/design-system/components/Header/Header.stories.tsx
+++ b/src/design-system/components/Header/Header.stories.tsx
@@ -1,18 +1,88 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import Header from "./Header";
-import React from "react";
+import type { Meta, StoryObj } from '@storybook/react';
+import Header from './Header';
+import React from 'react';
 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Header> = {
   component: Header,
-  title: "Components/Header",
-  argTypes: {},
+  title: 'Components/Header',
+  argTypes: {
+    isLoggedIn: {
+      control: 'boolean',
+      description: 'Whether the user is logged in',
+    },
+    userProfile: {
+      control: 'object',
+      description: 'User profile information',
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof Header>;
 
-/** Story for Default Header */
+/** Story for Default Header (Not Logged In) */
 export const Default: Story = {
-  args: {},
+  args: {
+    isLoggedIn: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+        <Story />
+        <div style={{ padding: '100px 20px' }}>
+          <h1>Scroll down to see the header collapse</h1>
+          <p>This is some content to demonstrate the scroll behavior.</p>
+        </div>
+      </div>
+    ),
+  ],
+};
+
+/** Story for Logged In User */
+export const LoggedIn: Story = {
+  args: {
+    isLoggedIn: true,
+    userProfile: {
+      name: 'John Doe',
+      avatar: '/logo.png',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+        <Story />
+        <div style={{ padding: '100px 20px' }}>
+          <h1>Scroll down to see the header collapse</h1>
+          <p>This is some content to demonstrate the scroll behavior.</p>
+        </div>
+      </div>
+    ),
+  ],
+};
+
+/** Story for Mobile View */
+export const Mobile: Story = {
+  args: {
+    isLoggedIn: false,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+        <Story />
+        <div style={{ padding: '100px 20px' }}>
+          <h1>Mobile Header</h1>
+          <p>Tap the menu button to see the mobile navigation.</p>
+        </div>
+      </div>
+    ),
+  ],
 };

--- a/src/design-system/components/Header/Header.stories.tsx
+++ b/src/design-system/components/Header/Header.stories.tsx
@@ -25,9 +25,14 @@ export default meta;
 type Story = StoryObj<typeof Header>;
 
 /** Story for Default Header (Not Logged In) */
-export const Default: Story = {
+export const Hamburger: Story = {
   args: {
     isLoggedIn: false,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
   },
   decorators: [
     (Story) => (
@@ -42,6 +47,29 @@ export const Default: Story = {
   ],
 };
 
+export const FullMenuDisplay: Story = {
+  args: {
+    isLoggedIn: false,
+    forceFullMenu: true,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+        <Story />
+        <div style={{ padding: '100px 20px' }}>
+          <h1>Full Menu Display Header</h1>
+          <p>All menu items are visible in the header without hamburger menu.</p>
+        </div>
+      </div>
+    ),
+  ],
+};
+
 /** Story for Logged In User */
 export const LoggedIn: Story = {
   args: {
@@ -49,6 +77,11 @@ export const LoggedIn: Story = {
     userProfile: {
       name: 'John Doe',
       avatar: '/logo.png',
+    },
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
     },
   },
   decorators: [

--- a/src/design-system/components/Header/Header.stories.tsx
+++ b/src/design-system/components/Header/Header.stories.tsx
@@ -97,3 +97,30 @@ export const Mobile: Story = {
     ),
   ],
 };
+
+/** Story for Mobile Logged In User */
+export const MobileLoggedIn: Story = {
+  args: {
+    isLoggedIn: true,
+    userProfile: {
+      name: "John Doe",
+      avatar: "/logo.png",
+    },
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "200vh", background: "linear-gradient(to bottom, #f0f0f0, #e0e0e0)" }}>
+        <Story />
+        <div style={{ padding: "100px 20px" }}>
+          <h1>Mobile Header with Logged In User</h1>
+          <p>Tap the menu button to see the mobile navigation with user profile.</p>
+        </div>
+      </div>
+    ),
+  ],
+};

--- a/src/design-system/components/Header/Header.stories.tsx
+++ b/src/design-system/components/Header/Header.stories.tsx
@@ -1,51 +1,28 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import Header from './Header';
-import React from 'react';
+import type { Meta, StoryObj } from "@storybook/react";
+import Header from "./Header";
+import React from "react";
 
 /** Define the control fields for Storybook */
 const meta: Meta<typeof Header> = {
   component: Header,
-  title: 'Components/Header',
+  title: "Components/Header",
   argTypes: {
     isLoggedIn: {
-      control: 'boolean',
-      description: 'Whether the user is logged in',
+      control: "boolean",
+      description: "Whether the user is logged in",
     },
     userProfile: {
-      control: 'object',
-      description: 'User profile information',
+      control: "object",
+      description: "User profile information",
     },
   },
   parameters: {
-    layout: 'fullscreen',
+    layout: "fullscreen",
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Header>;
-
-/** Story for Default Header (Not Logged In) */
-export const Hamburger: Story = {
-  args: {
-    isLoggedIn: false,
-  },
-  parameters: {
-    viewport: {
-      defaultViewport: 'desktop',
-    },
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
-        <Story />
-        <div style={{ padding: '100px 20px' }}>
-          <h1>Scroll down to see the header collapse</h1>
-          <p>This is some content to demonstrate the scroll behavior.</p>
-        </div>
-      </div>
-    ),
-  ],
-};
 
 export const FullMenuDisplay: Story = {
   args: {
@@ -54,14 +31,14 @@ export const FullMenuDisplay: Story = {
   },
   parameters: {
     viewport: {
-      defaultViewport: 'desktop',
+      defaultViewport: "desktop",
     },
   },
   decorators: [
     (Story) => (
-      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+      <div style={{ height: "200vh", background: "linear-gradient(to bottom, #f0f0f0, #e0e0e0)" }}>
         <Story />
-        <div style={{ padding: '100px 20px' }}>
+        <div style={{ padding: "100px 20px" }}>
           <h1>Full Menu Display Header</h1>
           <p>All menu items are visible in the header without hamburger menu.</p>
         </div>
@@ -70,27 +47,28 @@ export const FullMenuDisplay: Story = {
   ],
 };
 
-/** Story for Logged In User */
+/** Story for Logged In User with Full Menu */
 export const LoggedIn: Story = {
   args: {
     isLoggedIn: true,
     userProfile: {
-      name: 'John Doe',
-      avatar: '/logo.png',
+      name: "John Doe",
+      avatar: "/logo.png",
     },
+    forceFullMenu: true,
   },
   parameters: {
     viewport: {
-      defaultViewport: 'desktop',
+      defaultViewport: "desktop",
     },
   },
   decorators: [
     (Story) => (
-      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+      <div style={{ height: "200vh", background: "linear-gradient(to bottom, #f0f0f0, #e0e0e0)" }}>
         <Story />
-        <div style={{ padding: '100px 20px' }}>
-          <h1>Scroll down to see the header collapse</h1>
-          <p>This is some content to demonstrate the scroll behavior.</p>
+        <div style={{ padding: "100px 20px" }}>
+          <h1>Logged In User with Full Menu Display</h1>
+          <p>All menu items are visible in the header without hamburger menu.</p>
         </div>
       </div>
     ),
@@ -104,15 +82,15 @@ export const Mobile: Story = {
   },
   parameters: {
     viewport: {
-      defaultViewport: 'mobile1',
+      defaultViewport: "mobile1",
     },
   },
   decorators: [
     (Story) => (
-      <div style={{ height: '200vh', background: 'linear-gradient(to bottom, #f0f0f0, #e0e0e0)' }}>
+      <div style={{ height: "200vh", background: "linear-gradient(to bottom, #f0f0f0, #e0e0e0)" }}>
         <Story />
-        <div style={{ padding: '100px 20px' }}>
-          <h1>Mobile Header</h1>
+        <div style={{ padding: "100px 20px" }}>
+          <h1>Mobile Header with Hamburger Menu</h1>
           <p>Tap the menu button to see the mobile navigation.</p>
         </div>
       </div>

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import React, { useState, useEffect } from "react";
-import Box from "@/design-system/primitives/Box";
-import Button from "@/design-system/primitives/Button";
-import Link from "@/design-system/primitives/Link";
-import Image from "@/design-system/primitives/Image";
-import { DropdownInput, DropdownItem } from "@/design-system/primitives/DropdownInput";
-import { Menu, X, Search, User } from "lucide-react";
+import React, { useState, useEffect } from 'react';
+import Box from '@/design-system/primitives/Box';
+import Button from '@/design-system/primitives/Button';
+import Link from '@/design-system/primitives/Link';
+import Image from '@/design-system/primitives/Image';
+import { DropdownInput, DropdownItem } from '@/design-system/primitives/DropdownInput';
+import { Menu, X, Search, User } from 'lucide-react';
 
 interface HeaderProps {
   isLoggedIn?: boolean;
@@ -27,8 +27,8 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
       setIsScrolled(scrollTop > 50);
     };
 
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   const toggleMobileMenu = () => {
@@ -36,16 +36,16 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
   };
 
   const navigationItems = [
-    { label: "Print Articles", href: "/articles" },
-    { label: "About Us", href: "/about-us" },
+    { label: 'Print Articles', href: '/articles' },
+    { label: 'About Us', href: '/about-us' },
   ];
 
   const categories = [
-    { value: "science", label: "Science" },
-    { value: "technology", label: "Technology" },
-    { value: "health", label: "Health" },
-    { value: "environment", label: "Environment" },
-    { value: "research", label: "Research" },
+    { value: 'science', label: 'Science' },
+    { value: 'technology', label: 'Technology' },
+    { value: 'health', label: 'Health' },
+    { value: 'environment', label: 'Environment' },
+    { value: 'research', label: 'Research' },
   ];
 
   return (
@@ -58,7 +58,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
       color="white"
       className={`
         z-50 transition-all duration-300 ease-in-out
-        ${isScrolled ? "shadow-lg py-2" : "py-4"}
+        ${isScrolled ? 'shadow-lg py-2' : 'py-4'}
         border-b border-gray-200
       `}
     >
@@ -68,10 +68,10 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
           {/* Logo */}
           <Box className="flex-shrink-0">
             <Link href="/" newWindow={false} className="flex items-center">
-              <Box className={`transition-all duration-300 ${isScrolled ? "h-8 w-8" : "h-12 w-12"}`}>
-                <Image src="/logo.png" alt="NU Sci Magazine" width={isScrolled ? "w-8" : "w-12"} ratio={1} />
+              <Box className={`transition-all duration-300 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}>
+                <Image src="/logo.png" alt="NU Sci Magazine" width={isScrolled ? 'w-8' : 'w-12'} ratio={1} />
               </Box>
-              <Box className={`ml-3 ${isScrolled ? "hidden sm:block" : ""}`}>
+              <Box className={`ml-3 ${isScrolled ? 'hidden sm:block' : ''}`}>
                 <Box className="text-xl font-bold text-black">NU Sci</Box>
                 <Box className="text-sm text-gray-600">Magazine</Box>
               </Box>
@@ -79,7 +79,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
           </Box>
 
           {/* Desktop Navigation - Show always when forceFullMenu is true */}
-          <Box className={`${forceFullMenu ? "flex" : "hidden lg:flex"} items-center space-x-8`}>
+          <Box className={`${forceFullMenu ? 'flex' : 'hidden lg:flex'} items-center space-x-8`}>
             {navigationItems.map((item) => (
               <Link
                 key={item.label}
@@ -97,7 +97,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 placeholder="Categories"
                 onChange={(value) => {
                   // Handle category selection
-                  console.log("Selected category:", value);
+                  console.log('Selected category:', value);
                 }}
               >
                 {categories.map((category) => (
@@ -113,8 +113,8 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               variant="outline"
               size="sm"
               color="black"
-              onClick={() => (window.location.href = "/search")}
-              className="flex items-center"
+              onClick={() => (window.location.href = '/search')}
+              className="flex items-center h-[35px]"
             >
               <Search className="h-4 w-4 mr-1" />
               Search Articles
@@ -132,10 +132,16 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               </Link>
             ) : (
               <Box className="flex items-center space-x-2">
-                <Button variant="outline" size="sm" color="black" onClick={() => (window.location.href = "/login")}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  color="black"
+                  onClick={() => (window.location.href = '/login')}
+                  className="h-[32.5px]"
+                >
                   Login
                 </Button>
-                <Button size="sm" color="black" onClick={() => (window.location.href = "/signup")}>
+                <Button size="sm" color="black" onClick={() => (window.location.href = '/signup')}>
                   Sign Up
                 </Button>
               </Box>
@@ -173,7 +179,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 <DropdownInput
                   placeholder="Categories"
                   onChange={(value) => {
-                    console.log("Selected category:", value);
+                    console.log('Selected category:', value);
                     setIsMobileMenuOpen(false);
                   }}
                 >
@@ -191,7 +197,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 size="sm"
                 color="black"
                 onClick={() => {
-                  window.location.href = "/search";
+                  window.location.href = '/search';
                   setIsMobileMenuOpen(false);
                 }}
                 className="flex items-center justify-center"
@@ -219,7 +225,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                     size="sm"
                     color="black"
                     onClick={() => {
-                      window.location.href = "/login";
+                      window.location.href = '/login';
                       setIsMobileMenuOpen(false);
                     }}
                   >
@@ -229,7 +235,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                     size="sm"
                     color="black"
                     onClick={() => {
-                      window.location.href = "/signup";
+                      window.location.href = '/signup';
                       setIsMobileMenuOpen(false);
                     }}
                   >

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -41,11 +41,17 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
   ];
 
   const categories = [
-    { value: 'science', label: 'Science' },
-    { value: 'technology', label: 'Technology' },
-    { value: 'health', label: 'Health' },
+    { value: 'biology', label: 'Biology' },
+    { value: 'chemistry', label: 'Chemistry' },
     { value: 'environment', label: 'Environment' },
-    { value: 'research', label: 'Research' },
+    { value: 'health', label: 'Health' },
+    { value: 'newsletter', label: 'Newsletter' },
+    { value: 'opinion', label: 'Opinion' },
+    { value: 'physics', label: 'Physics' },
+    { value: 'psychology', label: 'Psychology' },
+    { value: 'space', label: 'Space' },
+    { value: 'technology', label: 'Technology' },
+    { value: 'world', label: 'World' },
   ];
 
   return (

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -186,21 +186,26 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
           <Box className="lg:hidden mt-4 pb-4 border-t border-gray-200">
             <Box className="flex flex-col space-y-4 pt-4">
               {navigationItems.map((item) => (
-                <Box key={item.label} onClick={() => setIsMobileMenuOpen(false)}>
-                  <Link
-                    href={item.href}
-                    newWindow={false}
-                    className="text-gray-700 hover:text-black transition-colors duration-200 font-medium"
-                  >
-                    {item.label}
-                  </Link>
-                </Box>
+                <Button
+                  key={item.label}
+                  variant="outline"
+                  size="sm"
+                  color="black"
+                  onClick={() => {
+                    window.location.href = item.href;
+                    setIsMobileMenuOpen(false);
+                  }}
+                  className="w-full justify-center"
+                >
+                  {item.label}
+                </Button>
               ))}
 
               {/* Mobile About Us Dropdown */}
               <Box className="w-full">
                 <DropdownInput
                   placeholder="About Us"
+                  className="w-full"
                   onChange={(value) => {
                     if (value === "about") {
                       window.location.href = "/about-us";
@@ -219,6 +224,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               <Box className="w-full">
                 <DropdownInput
                   placeholder="Categories"
+                  className="w-full"
                   onChange={(value) => {
                     window.location.href = `/${value}`;
                     setIsMobileMenuOpen(false);

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -103,7 +103,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 placeholder="Categories"
                 onChange={(value) => {
                   // Handle category selection
-                  console.log('Selected category:', value);
+                  window.location.href = `/${value}`;
                 }}
               >
                 {categories.map((category) => (
@@ -185,7 +185,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 <DropdownInput
                   placeholder="Categories"
                   onChange={(value) => {
-                    console.log('Selected category:', value);
+                    window.location.href = `/${value}`;
                     setIsMobileMenuOpen(false);
                   }}
                 >

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -1,5 +1,237 @@
-import Box from "@/design-system/primitives/Box";
+'use client';
 
-export default function Header() {
-  return <Box color="aqua">Hello</Box>;
+import React, { useState, useEffect } from 'react';
+import Box from '@/design-system/primitives/Box';
+import Button from '@/design-system/primitives/Button';
+import Link from '@/design-system/primitives/Link';
+import Image from '@/design-system/primitives/Image';
+import { DropdownInput, DropdownItem } from '@/design-system/primitives/DropdownInput';
+import { Menu, X, Search, User } from 'lucide-react';
+
+interface HeaderProps {
+  isLoggedIn?: boolean;
+  userProfile?: {
+    name: string;
+    avatar?: string;
+  };
+}
+
+export default function Header({ isLoggedIn = false, userProfile }: HeaderProps) {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      setIsScrolled(scrollTop > 50);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  const navigationItems = [
+    { label: 'Print Articles', href: '/articles' },
+    { label: 'About Us', href: '/about-us' },
+  ];
+
+  const categories = [
+    { value: 'science', label: 'Science' },
+    { value: 'technology', label: 'Technology' },
+    { value: 'health', label: 'Health' },
+    { value: 'environment', label: 'Environment' },
+    { value: 'research', label: 'Research' },
+  ];
+
+  return (
+    <Box
+      position='fixed'
+      top={0}
+      left={0}
+      right={0}
+      width='full'
+      color='white'
+      className={`
+        z-50 transition-all duration-300 ease-in-out
+        ${isScrolled ? 'shadow-lg py-2' : 'py-4'}
+        border-b border-gray-200
+      `}
+    >
+      <Box className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+        {/* Main Navigation */}
+        <Box className='flex items-center justify-between'>
+          {/* Logo */}
+          <Box className='flex-shrink-0'>
+            <Link href='/' newWindow={false} className='flex items-center'>
+              <Box className={`transition-all duration-300 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}>
+                <Image src='/logo.png' alt='NU Sci Magazine' width='w-12' ratio={1} />
+              </Box>
+              <Box className={`ml-3 ${isScrolled ? 'hidden sm:block' : ''}`}>
+                <Box className='text-xl font-bold text-black'>NU Sci</Box>
+                <Box className='text-sm text-gray-600'>Magazine</Box>
+              </Box>
+            </Link>
+          </Box>
+
+          {/* Desktop Navigation */}
+          <Box className='hidden lg:flex items-center space-x-8'>
+            {navigationItems.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                newWindow={false}
+                className='text-gray-700 hover:text-black transition-colors duration-200 font-medium'
+              >
+                {item.label}
+              </Link>
+            ))}
+
+            {/* Categories Dropdown */}
+            <DropdownInput
+              placeholder='Categories'
+              onChange={(value) => {
+                // Handle category selection
+                console.log('Selected category:', value);
+              }}
+            >
+              {categories.map((category) => (
+                <DropdownItem key={category.value} value={category.value}>
+                  {category.label}
+                </DropdownItem>
+              ))}
+            </DropdownInput>
+
+            {/* Search Link */}
+            <Link
+              href='/search'
+              newWindow={false}
+              className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+            >
+              <Search className='h-5 w-5' />
+              <span className='ml-1'>Search</span>
+            </Link>
+
+            {/* Profile - Conditionally Rendered */}
+            {isLoggedIn && userProfile ? (
+              <Link
+                href='/internal/profile'
+                newWindow={false}
+                className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+              >
+                <User className='h-5 w-5' />
+                <span className='ml-1'>{userProfile.name}</span>
+              </Link>
+            ) : (
+              <Box className='flex items-center space-x-2'>
+                <Button variant='outline' size='sm' color='black' onClick={() => (window.location.href = '/login')}>
+                  Login
+                </Button>
+                <Button size='sm' color='black' onClick={() => (window.location.href = '/signup')}>
+                  Sign Up
+                </Button>
+              </Box>
+            )}
+          </Box>
+
+          {/* Mobile Menu Button */}
+          <Box className='lg:hidden'>
+            <Button variant='outline' size='sm' color='black' onClick={toggleMobileMenu} className='p-2'>
+              {isMobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
+            </Button>
+          </Box>
+        </Box>
+
+        {/* Mobile Navigation Menu */}
+        {isMobileMenuOpen && (
+          <Box className='lg:hidden mt-4 pb-4 border-t border-gray-200'>
+            <Box className='flex flex-col space-y-4 pt-4'>
+              {navigationItems.map((item) => (
+                <Box onClick={() => setIsMobileMenuOpen(false)}>
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    newWindow={false}
+                    className='text-gray-700 hover:text-black transition-colors duration-200 font-medium'
+                  >
+                    {item.label}
+                  </Link>
+                </Box>
+              ))}
+
+              {/* Mobile Categories Dropdown */}
+              <Box className='w-full'>
+                <DropdownInput
+                  placeholder='Categories'
+                  onChange={(value) => {
+                    console.log('Selected category:', value);
+                    setIsMobileMenuOpen(false);
+                  }}
+                >
+                  {categories.map((category) => (
+                    <DropdownItem key={category.value} value={category.value}>
+                      {category.label}
+                    </DropdownItem>
+                  ))}
+                </DropdownInput>
+              </Box>
+
+              {/* Mobile Search Link */}
+              <Box onClick={() => setIsMobileMenuOpen(false)}>
+                <Link
+                  href='/search'
+                  newWindow={false}
+                  className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+                >
+                  <Search className='h-5 w-5' />
+                  <span className='ml-1'>Search</span>
+                </Link>
+              </Box>
+
+              {/* Mobile Profile Section */}
+              {isLoggedIn && userProfile ? (
+                <Box onClick={() => setIsMobileMenuOpen(false)}>
+                  <Link
+                    href='/internal/profile'
+                    newWindow={false}
+                    className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+                  >
+                    <User className='h-5 w-5' />
+                    <span className='ml-1'>{userProfile.name}</span>
+                  </Link>
+                </Box>
+              ) : (
+                <Box className='flex flex-col space-y-2'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    color='black'
+                    onClick={() => {
+                      window.location.href = '/login';
+                      setIsMobileMenuOpen(false);
+                    }}
+                  >
+                    Login
+                  </Button>
+                  <Button
+                    size='sm'
+                    color='black'
+                    onClick={() => {
+                      window.location.href = '/signup';
+                      setIsMobileMenuOpen(false);
+                    }}
+                  >
+                    Sign Up
+                  </Button>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
 }

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import Button from "@/design-system/primitives/Button";
 import Link from "@/design-system/primitives/Link";
 import Image from "@/design-system/primitives/Image";
 import { DropdownInput, DropdownItem } from "@/design-system/primitives/DropdownInput";
-import { Menu, X, Search, User } from "lucide-react";
+import Icon from "@/design-system/primitives/Icon";
 
 interface HeaderProps {
   isLoggedIn?: boolean;
@@ -14,7 +14,7 @@ interface HeaderProps {
     name: string;
     avatar?: string;
   };
-  forceFullMenu?: boolean; // New prop to force full menu display
+  forceFullMenu?: boolean;
 }
 
 export default function Header({ isLoggedIn = false, userProfile, forceFullMenu = false }: HeaderProps) {
@@ -35,10 +35,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
 
-  const navigationItems = [
-    { label: "Print Articles", href: "/articles" },
-    { label: "About Us", href: "/about-us" },
-  ];
+  const navigationItems = [{ label: "Print Articles", href: "/articles" }];
 
   const categories = [
     { value: "biology", label: "Biology" },
@@ -100,6 +97,23 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               </Link>
             ))}
 
+            {/* About Us Dropdown */}
+            <Box className="relative">
+              <DropdownInput
+                placeholder="About Us"
+                onChange={(value) => {
+                  if (value === "about") {
+                    window.location.href = "/about-us";
+                  } else if (value === "eboard") {
+                    window.location.href = "/teams/eboard";
+                  }
+                }}
+              >
+                <DropdownItem value="about">Teams</DropdownItem>
+                <DropdownItem value="eboard">Eboard & Editors</DropdownItem>
+              </DropdownInput>
+            </Box>
+
             {/* Categories Dropdown */}
             <Box className="relative">
               <DropdownInput
@@ -125,7 +139,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               onClick={() => (window.location.href = "/search")}
               className="flex items-center h-[35px]"
             >
-              <Search className="h-4 w-4 mr-1" />
+              <Icon icon="search" size="sm" className="mr-1" />
               Search Articles
             </Button>
 
@@ -136,7 +150,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 newWindow={false}
                 className="flex items-center text-gray-700 hover:text-black transition-colors duration-200"
               >
-                <User className="h-5 w-5" />
+                <Icon icon="user" size="sm" />
                 <span className="ml-1">{userProfile.name}</span>
               </Link>
             ) : (
@@ -161,7 +175,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
           {!forceFullMenu && (
             <Box className="lg:hidden">
               <Button variant="outline" size="sm" color="black" onClick={toggleMobileMenu} className="p-2">
-                {isMobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+                {isMobileMenuOpen ? <Icon icon="x" size="sm" /> : <Icon icon="menu" size="sm" />}
               </Button>
             </Box>
           )}
@@ -182,6 +196,24 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                   </Link>
                 </Box>
               ))}
+
+              {/* Mobile About Us Dropdown */}
+              <Box className="w-full">
+                <DropdownInput
+                  placeholder="About Us"
+                  onChange={(value) => {
+                    if (value === "about") {
+                      window.location.href = "/about-us";
+                    } else if (value === "eboard") {
+                      window.location.href = "/teams/eboard";
+                    }
+                    setIsMobileMenuOpen(false);
+                  }}
+                >
+                  <DropdownItem value="about">Teams</DropdownItem>
+                  <DropdownItem value="eboard">Eboard & Editors</DropdownItem>
+                </DropdownInput>
+              </Box>
 
               {/* Mobile Categories Dropdown */}
               <Box className="w-full">
@@ -211,7 +243,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 }}
                 className="flex items-center justify-center"
               >
-                <Search className="h-4 w-4 mr-1" />
+                <Icon icon="search" size="sm" className="mr-1" />
                 Search Articles
               </Button>
 
@@ -223,7 +255,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                     newWindow={false}
                     className="flex items-center text-gray-700 hover:text-black transition-colors duration-200"
                   >
-                    <User className="h-5 w-5" />
+                    <Icon icon="user" size="sm" />
                     <span className="ml-1">{userProfile.name}</span>
                   </Link>
                 </Box>

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Box from '@/design-system/primitives/Box';
-import Button from '@/design-system/primitives/Button';
-import Link from '@/design-system/primitives/Link';
-import Image from '@/design-system/primitives/Image';
-import { DropdownInput, DropdownItem } from '@/design-system/primitives/DropdownInput';
-import { Menu, X, Search, User } from 'lucide-react';
+import React, { useState, useEffect } from "react";
+import Box from "@/design-system/primitives/Box";
+import Button from "@/design-system/primitives/Button";
+import Link from "@/design-system/primitives/Link";
+import Image from "@/design-system/primitives/Image";
+import { DropdownInput, DropdownItem } from "@/design-system/primitives/DropdownInput";
+import { Menu, X, Search, User } from "lucide-react";
 
 interface HeaderProps {
   isLoggedIn?: boolean;
@@ -27,8 +27,8 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
       setIsScrolled(scrollTop > 50);
     };
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   const toggleMobileMenu = () => {
@@ -36,102 +36,106 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
   };
 
   const navigationItems = [
-    { label: 'Print Articles', href: '/articles' },
-    { label: 'About Us', href: '/about-us' },
+    { label: "Print Articles", href: "/articles" },
+    { label: "About Us", href: "/about-us" },
   ];
 
   const categories = [
-    { value: 'science', label: 'Science' },
-    { value: 'technology', label: 'Technology' },
-    { value: 'health', label: 'Health' },
-    { value: 'environment', label: 'Environment' },
-    { value: 'research', label: 'Research' },
+    { value: "science", label: "Science" },
+    { value: "technology", label: "Technology" },
+    { value: "health", label: "Health" },
+    { value: "environment", label: "Environment" },
+    { value: "research", label: "Research" },
   ];
 
   return (
     <Box
-      position='fixed'
+      position="fixed"
       top={0}
       left={0}
       right={0}
-      width='full'
-      color='white'
+      width="full"
+      color="white"
       className={`
         z-50 transition-all duration-300 ease-in-out
-        ${isScrolled ? 'shadow-lg py-2' : 'py-4'}
+        ${isScrolled ? "shadow-lg py-2" : "py-4"}
         border-b border-gray-200
       `}
     >
-      <Box className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+      <Box className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Main Navigation */}
-        <Box className='flex items-center justify-between'>
+        <Box className="flex items-center justify-between">
           {/* Logo */}
-          <Box className='flex-shrink-0'>
-            <Link href='/' newWindow={false} className='flex items-center'>
-              <Box className={`transition-all duration-300 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}>
-                <Image src='/logo.png' alt='NU Sci Magazine' width={isScrolled ? 'w-8' : 'w-12'} ratio={1} />
+          <Box className="flex-shrink-0">
+            <Link href="/" newWindow={false} className="flex items-center">
+              <Box className={`transition-all duration-300 ${isScrolled ? "h-8 w-8" : "h-12 w-12"}`}>
+                <Image src="/logo.png" alt="NU Sci Magazine" width={isScrolled ? "w-8" : "w-12"} ratio={1} />
               </Box>
-              <Box className={`ml-3 ${isScrolled ? 'hidden sm:block' : ''}`}>
-                <Box className='text-xl font-bold text-black'>NU Sci</Box>
-                <Box className='text-sm text-gray-600'>Magazine</Box>
+              <Box className={`ml-3 ${isScrolled ? "hidden sm:block" : ""}`}>
+                <Box className="text-xl font-bold text-black">NU Sci</Box>
+                <Box className="text-sm text-gray-600">Magazine</Box>
               </Box>
             </Link>
           </Box>
 
           {/* Desktop Navigation - Show always when forceFullMenu is true */}
-          <Box className={`${forceFullMenu ? 'flex' : 'hidden lg:flex'} items-center space-x-8`}>
+          <Box className={`${forceFullMenu ? "flex" : "hidden lg:flex"} items-center space-x-8`}>
             {navigationItems.map((item) => (
               <Link
                 key={item.label}
                 href={item.href}
                 newWindow={false}
-                className='text-gray-700 hover:text-black transition-colors duration-200 font-medium'
+                className="text-gray-700 hover:text-black transition-colors duration-200 font-medium"
               >
                 {item.label}
               </Link>
             ))}
 
             {/* Categories Dropdown */}
-            <DropdownInput
-              placeholder='Categories'
-              onChange={(value) => {
-                // Handle category selection
-                console.log('Selected category:', value);
-              }}
-            >
-              {categories.map((category) => (
-                <DropdownItem key={category.value} value={category.value}>
-                  {category.label}
-                </DropdownItem>
-              ))}
-            </DropdownInput>
+            <Box className="relative">
+              <DropdownInput
+                placeholder="Categories"
+                onChange={(value) => {
+                  // Handle category selection
+                  console.log("Selected category:", value);
+                }}
+              >
+                {categories.map((category) => (
+                  <DropdownItem key={category.value} value={category.value}>
+                    {category.label}
+                  </DropdownItem>
+                ))}
+              </DropdownInput>
+            </Box>
 
-            {/* Search Link */}
-            <Link
-              href='/search'
-              newWindow={false}
-              className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+            {/* Search Articles Button */}
+            <Button
+              variant="outline"
+              size="sm"
+              color="black"
+              onClick={() => (window.location.href = "/search")}
+              className="flex items-center"
             >
-              <Search className='h-5 w-5' />
-              <span className='ml-1'>Search</span>
-            </Link>
+              <Search className="h-4 w-4 mr-1" />
+              Search Articles
+            </Button>
 
             {/* Profile - Conditionally Rendered */}
             {isLoggedIn && userProfile ? (
               <Link
-                href='/internal/profile'
+                href="/internal/profile"
                 newWindow={false}
-                className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+                className="flex items-center text-gray-700 hover:text-black transition-colors duration-200"
               >
-                <User className='h-5 w-5' />
-                <span className='ml-1'>{userProfile.name}</span>
+                <User className="h-5 w-5" />
+                <span className="ml-1">{userProfile.name}</span>
               </Link>
             ) : (
-              <Box className='flex items-center space-x-2'>
-                <Button variant='outline' size='sm' color='black' onClick={() => (window.location.href = '/login')}>
+              <Box className="flex items-center space-x-2">
+                <Button variant="outline" size="sm" color="black" onClick={() => (window.location.href = "/login")}>
                   Login
                 </Button>
-                <Button size='sm' color='black' onClick={() => (window.location.href = '/signup')}>
+                <Button size="sm" color="black" onClick={() => (window.location.href = "/signup")}>
                   Sign Up
                 </Button>
               </Box>
@@ -140,9 +144,9 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
 
           {/* Mobile Menu Button - Hide when forceFullMenu is true */}
           {!forceFullMenu && (
-            <Box className='lg:hidden'>
-              <Button variant='outline' size='sm' color='black' onClick={toggleMobileMenu} className='p-2'>
-                {isMobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
+            <Box className="lg:hidden">
+              <Button variant="outline" size="sm" color="black" onClick={toggleMobileMenu} className="p-2">
+                {isMobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
               </Button>
             </Box>
           )}
@@ -150,14 +154,14 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
 
         {/* Mobile Navigation Menu - Only show when not forceFullMenu */}
         {!forceFullMenu && isMobileMenuOpen && (
-          <Box className='lg:hidden mt-4 pb-4 border-t border-gray-200'>
-            <Box className='flex flex-col space-y-4 pt-4'>
+          <Box className="lg:hidden mt-4 pb-4 border-t border-gray-200">
+            <Box className="flex flex-col space-y-4 pt-4">
               {navigationItems.map((item) => (
                 <Box key={item.label} onClick={() => setIsMobileMenuOpen(false)}>
                   <Link
                     href={item.href}
                     newWindow={false}
-                    className='text-gray-700 hover:text-black transition-colors duration-200 font-medium'
+                    className="text-gray-700 hover:text-black transition-colors duration-200 font-medium"
                   >
                     {item.label}
                   </Link>
@@ -165,11 +169,11 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               ))}
 
               {/* Mobile Categories Dropdown */}
-              <Box className='w-full'>
+              <Box className="w-full">
                 <DropdownInput
-                  placeholder='Categories'
+                  placeholder="Categories"
                   onChange={(value) => {
-                    console.log('Selected category:', value);
+                    console.log("Selected category:", value);
                     setIsMobileMenuOpen(false);
                   }}
                 >
@@ -181,48 +185,51 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 </DropdownInput>
               </Box>
 
-              {/* Mobile Search Link */}
-              <Box onClick={() => setIsMobileMenuOpen(false)}>
-                <Link
-                  href='/search'
-                  newWindow={false}
-                  className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
-                >
-                  <Search className='h-5 w-5' />
-                  <span className='ml-1'>Search</span>
-                </Link>
-              </Box>
+              {/* Mobile Search Button */}
+              <Button
+                variant="outline"
+                size="sm"
+                color="black"
+                onClick={() => {
+                  window.location.href = "/search";
+                  setIsMobileMenuOpen(false);
+                }}
+                className="flex items-center justify-center"
+              >
+                <Search className="h-4 w-4 mr-1" />
+                Search Articles
+              </Button>
 
               {/* Mobile Profile Section */}
               {isLoggedIn && userProfile ? (
                 <Box onClick={() => setIsMobileMenuOpen(false)}>
                   <Link
-                    href='/internal/profile'
+                    href="/internal/profile"
                     newWindow={false}
-                    className='flex items-center text-gray-700 hover:text-black transition-colors duration-200'
+                    className="flex items-center text-gray-700 hover:text-black transition-colors duration-200"
                   >
-                    <User className='h-5 w-5' />
-                    <span className='ml-1'>{userProfile.name}</span>
+                    <User className="h-5 w-5" />
+                    <span className="ml-1">{userProfile.name}</span>
                   </Link>
                 </Box>
               ) : (
-                <Box className='flex flex-col space-y-2'>
+                <Box className="flex flex-col space-y-2">
                   <Button
-                    variant='outline'
-                    size='sm'
-                    color='black'
+                    variant="outline"
+                    size="sm"
+                    color="black"
                     onClick={() => {
-                      window.location.href = '/login';
+                      window.location.href = "/login";
                       setIsMobileMenuOpen(false);
                     }}
                   >
                     Login
                   </Button>
                   <Button
-                    size='sm'
-                    color='black'
+                    size="sm"
+                    color="black"
                     onClick={() => {
-                      window.location.href = '/signup';
+                      window.location.href = "/signup";
                       setIsMobileMenuOpen(false);
                     }}
                   >

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Box from '@/design-system/primitives/Box';
-import Button from '@/design-system/primitives/Button';
-import Link from '@/design-system/primitives/Link';
-import Image from '@/design-system/primitives/Image';
-import { DropdownInput, DropdownItem } from '@/design-system/primitives/DropdownInput';
-import { Menu, X, Search, User } from 'lucide-react';
+import React, { useState, useEffect } from "react";
+import Box from "@/design-system/primitives/Box";
+import Button from "@/design-system/primitives/Button";
+import Link from "@/design-system/primitives/Link";
+import Image from "@/design-system/primitives/Image";
+import { DropdownInput, DropdownItem } from "@/design-system/primitives/DropdownInput";
+import { Menu, X, Search, User } from "lucide-react";
 
 interface HeaderProps {
   isLoggedIn?: boolean;
@@ -27,8 +27,8 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
       setIsScrolled(scrollTop > 50);
     };
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   const toggleMobileMenu = () => {
@@ -36,22 +36,22 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
   };
 
   const navigationItems = [
-    { label: 'Print Articles', href: '/articles' },
-    { label: 'About Us', href: '/about-us' },
+    { label: "Print Articles", href: "/articles" },
+    { label: "About Us", href: "/about-us" },
   ];
 
   const categories = [
-    { value: 'biology', label: 'Biology' },
-    { value: 'chemistry', label: 'Chemistry' },
-    { value: 'environment', label: 'Environment' },
-    { value: 'health', label: 'Health' },
-    { value: 'newsletter', label: 'Newsletter' },
-    { value: 'opinion', label: 'Opinion' },
-    { value: 'physics', label: 'Physics' },
-    { value: 'psychology', label: 'Psychology' },
-    { value: 'space', label: 'Space' },
-    { value: 'technology', label: 'Technology' },
-    { value: 'world', label: 'World' },
+    { value: "biology", label: "Biology" },
+    { value: "chemistry", label: "Chemistry" },
+    { value: "environment", label: "Environment" },
+    { value: "health", label: "Health" },
+    { value: "newsletter", label: "Newsletter" },
+    { value: "opinion", label: "Opinion" },
+    { value: "physics", label: "Physics" },
+    { value: "psychology", label: "Psychology" },
+    { value: "space", label: "Space" },
+    { value: "technology", label: "Technology" },
+    { value: "world", label: "World" },
   ];
 
   return (
@@ -64,7 +64,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
       color="white"
       className={`
         z-50 transition-all duration-300 ease-in-out
-        ${isScrolled ? 'shadow-lg py-2' : 'py-4'}
+        ${isScrolled ? "shadow-lg py-2" : "py-4"}
         border-b border-gray-200
       `}
     >
@@ -74,18 +74,21 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
           {/* Logo */}
           <Box className="flex-shrink-0">
             <Link href="/" newWindow={false} className="flex items-center">
-              <Box className={`transition-all duration-300 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}>
-                <Image src="/logo.png" alt="NU Sci Magazine" width={isScrolled ? 'w-8' : 'w-12'} ratio={1} />
-              </Box>
-              <Box className={`ml-3 ${isScrolled ? 'hidden sm:block' : ''}`}>
-                <Box className="text-xl font-bold text-black">NU Sci</Box>
-                <Box className="text-sm text-gray-600">Magazine</Box>
-              </Box>
+              {isScrolled ? (
+                <Box className="transition-all duration-300 h-8 w-8">
+                  <Image src="/logo.png" alt="NU Sci Magazine" width="w-8" ratio={1} />
+                </Box>
+              ) : (
+                <Box className="ml-3">
+                  <Box className="text-xl font-bold text-black">NU Sci</Box>
+                  <Box className="text-sm text-gray-600">Magazine</Box>
+                </Box>
+              )}
             </Link>
           </Box>
 
           {/* Desktop Navigation - Show always when forceFullMenu is true */}
-          <Box className={`${forceFullMenu ? 'flex' : 'hidden lg:flex'} items-center space-x-8`}>
+          <Box className={`${forceFullMenu ? "flex" : "hidden lg:flex"} items-center space-x-8`}>
             {navigationItems.map((item) => (
               <Link
                 key={item.label}
@@ -119,7 +122,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
               variant="outline"
               size="sm"
               color="black"
-              onClick={() => (window.location.href = '/search')}
+              onClick={() => (window.location.href = "/search")}
               className="flex items-center h-[35px]"
             >
               <Search className="h-4 w-4 mr-1" />
@@ -142,12 +145,12 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                   variant="outline"
                   size="sm"
                   color="black"
-                  onClick={() => (window.location.href = '/login')}
+                  onClick={() => (window.location.href = "/login")}
                   className="h-[32.5px]"
                 >
                   Login
                 </Button>
-                <Button size="sm" color="black" onClick={() => (window.location.href = '/signup')}>
+                <Button size="sm" color="black" onClick={() => (window.location.href = "/signup")}>
                   Sign Up
                 </Button>
               </Box>
@@ -203,7 +206,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                 size="sm"
                 color="black"
                 onClick={() => {
-                  window.location.href = '/search';
+                  window.location.href = "/search";
                   setIsMobileMenuOpen(false);
                 }}
                 className="flex items-center justify-center"
@@ -231,7 +234,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                     size="sm"
                     color="black"
                     onClick={() => {
-                      window.location.href = '/login';
+                      window.location.href = "/login";
                       setIsMobileMenuOpen(false);
                     }}
                   >
@@ -241,7 +244,7 @@ export default function Header({ isLoggedIn = false, userProfile, forceFullMenu 
                     size="sm"
                     color="black"
                     onClick={() => {
-                      window.location.href = '/signup';
+                      window.location.href = "/signup";
                       setIsMobileMenuOpen(false);
                     }}
                   >

--- a/src/design-system/components/Header/Header.tsx
+++ b/src/design-system/components/Header/Header.tsx
@@ -14,9 +14,10 @@ interface HeaderProps {
     name: string;
     avatar?: string;
   };
+  forceFullMenu?: boolean; // New prop to force full menu display
 }
 
-export default function Header({ isLoggedIn = false, userProfile }: HeaderProps) {
+export default function Header({ isLoggedIn = false, userProfile, forceFullMenu = false }: HeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -68,7 +69,7 @@ export default function Header({ isLoggedIn = false, userProfile }: HeaderProps)
           <Box className='flex-shrink-0'>
             <Link href='/' newWindow={false} className='flex items-center'>
               <Box className={`transition-all duration-300 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}>
-                <Image src='/logo.png' alt='NU Sci Magazine' width='w-12' ratio={1} />
+                <Image src='/logo.png' alt='NU Sci Magazine' width={isScrolled ? 'w-8' : 'w-12'} ratio={1} />
               </Box>
               <Box className={`ml-3 ${isScrolled ? 'hidden sm:block' : ''}`}>
                 <Box className='text-xl font-bold text-black'>NU Sci</Box>
@@ -77,8 +78,8 @@ export default function Header({ isLoggedIn = false, userProfile }: HeaderProps)
             </Link>
           </Box>
 
-          {/* Desktop Navigation */}
-          <Box className='hidden lg:flex items-center space-x-8'>
+          {/* Desktop Navigation - Show always when forceFullMenu is true */}
+          <Box className={`${forceFullMenu ? 'flex' : 'hidden lg:flex'} items-center space-x-8`}>
             {navigationItems.map((item) => (
               <Link
                 key={item.label}
@@ -137,22 +138,23 @@ export default function Header({ isLoggedIn = false, userProfile }: HeaderProps)
             )}
           </Box>
 
-          {/* Mobile Menu Button */}
-          <Box className='lg:hidden'>
-            <Button variant='outline' size='sm' color='black' onClick={toggleMobileMenu} className='p-2'>
-              {isMobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
-            </Button>
-          </Box>
+          {/* Mobile Menu Button - Hide when forceFullMenu is true */}
+          {!forceFullMenu && (
+            <Box className='lg:hidden'>
+              <Button variant='outline' size='sm' color='black' onClick={toggleMobileMenu} className='p-2'>
+                {isMobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
+              </Button>
+            </Box>
+          )}
         </Box>
 
-        {/* Mobile Navigation Menu */}
-        {isMobileMenuOpen && (
+        {/* Mobile Navigation Menu - Only show when not forceFullMenu */}
+        {!forceFullMenu && isMobileMenuOpen && (
           <Box className='lg:hidden mt-4 pb-4 border-t border-gray-200'>
             <Box className='flex flex-col space-y-4 pt-4'>
               {navigationItems.map((item) => (
-                <Box onClick={() => setIsMobileMenuOpen(false)}>
+                <Box key={item.label} onClick={() => setIsMobileMenuOpen(false)}>
                   <Link
-                    key={item.label}
                     href={item.href}
                     newWindow={false}
                     className='text-gray-700 hover:text-black transition-colors duration-200 font-medium'

--- a/src/design-system/components/Header/index.tsx
+++ b/src/design-system/components/Header/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Header';

--- a/src/design-system/primitives/DropdownInput/DropdownInput.tsx
+++ b/src/design-system/primitives/DropdownInput/DropdownInput.tsx
@@ -45,7 +45,7 @@ export function DropdownInput({
         </Select.Icon>
       </Select.Trigger>
       <Select.Portal>
-        <Select.Content className="overflow-hidden rounded-md bg-white shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]">
+        <Select.Content className="z-[60] overflow-hidden rounded-md bg-white shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]">
           <Select.ScrollUpButton />
           <Select.Viewport>{children}</Select.Viewport>
           <Select.ScrollDownButton />

--- a/src/design-system/primitives/DropdownInput/DropdownInput.tsx
+++ b/src/design-system/primitives/DropdownInput/DropdownInput.tsx
@@ -18,18 +18,21 @@ export function DropdownItem({ className, value, children, disabled, ...variantP
 export function DropdownInput({ onChange, className, children, placeholder, ...variantProps }: DropdownInputProps) {
   return (
     <Select.Root onValueChange={onChange}>
-      <Select.Trigger className="inline-flex h-[35px] items-center justify-center gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black border-2 border-black">
+      <Select.Trigger className="inline-flex h-[35px] min-w-[150px] items-center justify-between gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black border-2 border-black">
         <Select.Value placeholder={placeholder} />
         <Select.Icon>
           <ChevronDownIcon />
         </Select.Icon>
       </Select.Trigger>
       <Select.Portal>
-        <Select.Content className="z-[60] overflow-hidden rounded-md bg-white shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]">
+        <Select.Content
+          position="popper"
+          sideOffset={5}
+          className="z-[60] max-h-[250px] overflow-y-auto rounded-md bg-white shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]"
+        >
           <Select.ScrollUpButton />
           <Select.Viewport>{children}</Select.Viewport>
           <Select.ScrollDownButton />
-          <Select.Arrow />
         </Select.Content>
       </Select.Portal>
     </Select.Root>

--- a/src/design-system/primitives/DropdownInput/DropdownInput.tsx
+++ b/src/design-system/primitives/DropdownInput/DropdownInput.tsx
@@ -1,8 +1,8 @@
-import { Select } from 'radix-ui';
-import clsx from 'clsx';
+import { Select } from "radix-ui";
+import clsx from "clsx";
 
-import { dropdownItemVariants, DropdownInputProps, DropdownItemProps } from './variants';
-import { CheckIcon, ChevronDownIcon } from '@radix-ui/react-icons';
+import { dropdownItemVariants, DropdownInputProps, DropdownItemProps } from "./variants";
+import { CheckIcon, ChevronDownIcon } from "@radix-ui/react-icons";
 
 export function DropdownItem({ className, value, children, disabled, ...variantProps }: DropdownItemProps) {
   return (
@@ -18,7 +18,12 @@ export function DropdownItem({ className, value, children, disabled, ...variantP
 export function DropdownInput({ onChange, className, children, placeholder, ...variantProps }: DropdownInputProps) {
   return (
     <Select.Root onValueChange={onChange}>
-      <Select.Trigger className="inline-flex h-[35px] min-w-[150px] items-center justify-between gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black border-2 border-black">
+      <Select.Trigger
+        className={clsx(
+          "inline-flex h-[35px] min-w-[150px] items-center justify-between gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black border-2 border-black",
+          className
+        )}
+      >
         <Select.Value placeholder={placeholder} />
         <Select.Icon>
           <ChevronDownIcon />

--- a/src/design-system/primitives/DropdownInput/DropdownInput.tsx
+++ b/src/design-system/primitives/DropdownInput/DropdownInput.tsx
@@ -1,26 +1,12 @@
-import { Select } from "radix-ui";
-import clsx from "clsx";
+import { Select } from 'radix-ui';
+import clsx from 'clsx';
 
-import {
-  dropdownItemVariants,
-  DropdownInputProps,
-  DropdownItemProps,
-} from "./variants";
-import { CheckIcon, ChevronDownIcon } from "@radix-ui/react-icons";
+import { dropdownItemVariants, DropdownInputProps, DropdownItemProps } from './variants';
+import { CheckIcon, ChevronDownIcon } from '@radix-ui/react-icons';
 
-export function DropdownItem({
-  className,
-  value,
-  children,
-  disabled,
-  ...variantProps
-}: DropdownItemProps) {
+export function DropdownItem({ className, value, children, disabled, ...variantProps }: DropdownItemProps) {
   return (
-    <Select.Item
-      value={value}
-      disabled={disabled}
-      className={clsx(dropdownItemVariants(variantProps), className)}
-    >
+    <Select.Item value={value} disabled={disabled} className={clsx(dropdownItemVariants(variantProps), className)}>
       <Select.ItemText>{children}</Select.ItemText>
       <Select.ItemIndicator className="absolute left-0 inline-flex w-[25px] items-center justify-center">
         <CheckIcon />
@@ -29,16 +15,10 @@ export function DropdownItem({
   );
 }
 
-export function DropdownInput({
-  onChange,
-  className,
-  children,
-  placeholder,
-  ...variantProps
-}: DropdownInputProps) {
+export function DropdownInput({ onChange, className, children, placeholder, ...variantProps }: DropdownInputProps) {
   return (
     <Select.Root onValueChange={onChange}>
-      <Select.Trigger className="inline-flex h-[35px] items-center justify-center gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black">
+      <Select.Trigger className="inline-flex h-[35px] items-center justify-center gap-[5px] rounded bg-white px-[15px] text-[13px] leading-none text-violet11 shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black border-2 border-black">
         <Select.Value placeholder={placeholder} />
         <Select.Icon>
           <ChevronDownIcon />

--- a/src/design-system/primitives/Icon/variants.ts
+++ b/src/design-system/primitives/Icon/variants.ts
@@ -14,6 +14,8 @@ import {
   Trash2,
   ZoomIn,
   ZoomOut,
+  Menu,
+  X,
 } from "lucide-react";
 import { InstagramLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
 
@@ -73,6 +75,8 @@ export const iconMap = {
   trash: Trash2,
   zoomin: ZoomIn,
   zoomout: ZoomOut,
+  menu: Menu,
+  x: X,
 };
 
 export type IconName = keyof typeof iconMap;


### PR DESCRIPTION
## Front End Pull Request

[comment]: <> (All sections are required.)

### Brief Summary
[comment]: <> (Put a brief summary of your changes.)
- Added a component for header/navbar with 4 stories:
- Full Header (default, with Login and Sign Up buttons)
- Logged In (full menu when user is logged in)
- Mobile (for small screens, hamburger menu and user is not logged in)
- Mobile Logged In (mobile device and user is logged in)

- In order for the dropdown formatting to look right, some modifications to the dropdown primitive were made
- The include changing the z-depth (otherwise the dropdown options would appear beneath the navbar)
- Adding a black outline to stand out visually
### Questions / Considerations for the Future
[comment]: <> (Note any questions, or things to note that might involve this PR in the future.)
- As mentioned I added a border to the dropdown primitive.  One might consider modifying the dropdown primitive to be more adaptable for customization, such as border color

### Image of changes
[comment]: <> (Upload at least one image displaying the changes you've made.)

<img width="1422" height="550" alt="Screenshot 2025-10-03 at 11 17 50 AM" src="https://github.com/user-attachments/assets/ae772ff4-42fe-48b1-902d-28e3546f94c6" />
<img width="1423" height="552" alt="Screenshot 2025-10-03 at 11 18 05 AM" src="https://github.com/user-attachments/assets/2da59a3f-3c06-462e-8ee4-51b7fa28c50f" />
<img width="319" height="554" alt="Screenshot 2025-10-03 at 11 18 16 AM" src="https://github.com/user-attachments/assets/96e79897-0064-462b-88c8-8bd103efbb5e" />
<img width="316" height="554" alt="Screenshot 2025-10-03 at 11 18 27 AM" src="https://github.com/user-attachments/assets/4a8aaed4-0f52-4687-bfce-f028c10d1abc" />
<img width="317" height="553" alt="Screenshot 2025-10-03 at 11 18 42 AM" src="https://github.com/user-attachments/assets/145f1503-ed6f-44de-b2d0-8b95c4c30a3b" />

[comment]: <> (Put the ticket # this PR closes.)
Closes #51 
