### PR TITLE
50 Create Footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-switch": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.11",
-        "@radix-ui/react-select": "^2.2.5",
         "@types/react-router-dom": "^5.3.3",
         "clsx": "^2.1.1",
         "lucide-react": "^0.510.0",
@@ -13463,6 +13463,49 @@
         }
       }
     },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-select": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
+      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/radix-ui/node_modules/@radix-ui/react-switch": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
@@ -13506,49 +13549,6 @@
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-roving-focus": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-select": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
-      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/number": "1.1.0",
-        "@radix-ui/primitive": "1.1.1",
-        "@radix-ui/react-collection": "1.1.2",
-        "@radix-ui/react-compose-refs": "1.1.1",
-        "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.5",
-        "@radix-ui/react-focus-guards": "1.1.1",
-        "@radix-ui/react-focus-scope": "1.1.2",
-        "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-popper": "1.2.2",
-        "@radix-ui/react-portal": "1.1.4",
-        "@radix-ui/react-primitive": "2.0.2",
-        "@radix-ui/react-slot": "1.1.2",
-        "@radix-ui/react-use-callback-ref": "1.1.0",
-        "@radix-ui/react-use-controllable-state": "1.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0",
-        "@radix-ui/react-use-previous": "1.1.0",
-        "@radix-ui/react-visually-hidden": "1.1.2",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/src/design-system/components/Footer/Footer.stories.tsx
+++ b/src/design-system/components/Footer/Footer.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Footer from "./Footer";
+import React from "react";
+
+/** Define the control fields for Storybook */
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+  title: "Components/Footer",
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+/** Story for Default Header */
+export const Default: Story = {
+  args: {},
+};

--- a/src/design-system/components/Footer/Footer.tsx
+++ b/src/design-system/components/Footer/Footer.tsx
@@ -9,6 +9,7 @@ export interface FooterProps {
 const Footer: React.FC<FooterProps> = ({ className = '' }) => {
   const currentYear = new Date().getFullYear();
 
+  //Making the links to each social media correspond to their logos.
   const socialLinks = [
     {
       label: 'Instagram',
@@ -31,12 +32,12 @@ const Footer: React.FC<FooterProps> = ({ className = '' }) => {
     <footer className={`bg-black-900 text-black ${className}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="flex flex-col items-center space-y-8">
-          {/* NU Sci Logo */}
+          {/* The NU Sci logo section */}
           <div className="text-center">
             <h3 className="text-4xl font-bold text-black-500">NU Sci</h3>
           </div>
 
-          {/* Social Links */}
+          {/* The social media section */}
           <div className="flex space-x-6">
             {socialLinks.map((social) => (
               <Link
@@ -51,13 +52,13 @@ const Footer: React.FC<FooterProps> = ({ className = '' }) => {
             ))}
           </div>
 
-          {/* Copyright */}
+          {/* The copyright section */}
           <div className="text-center space-y-2">
             <p className="text-sm text-black-400">
               © {currentYear} NU Sci. All rights reserved.
             </p>
             <p className="text-sm text-black-400">
-              This website is built and maintained by the NU Sci web and software team
+              This website is built and maintained by the NU Sci web and software team.
             </p>
           </div>
         </div>

--- a/src/design-system/components/Footer/Footer.tsx
+++ b/src/design-system/components/Footer/Footer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Link from '@/primitives/Link';
 import Icon from '@/primitives/Icon';
+import Image from '@/design-system/primitives/Image';
+
 
 export interface FooterProps {
   className?: string;
@@ -29,41 +31,36 @@ const Footer: React.FC<FooterProps> = ({ className = '' }) => {
   ];
 
   return (
-    <footer className={`bg-black-900 text-black ${className}`}>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="flex flex-col items-center space-y-8">
-          {/* The NU Sci logo section */}
-          <div className="text-center">
-            <h3 className="text-4xl font-bold text-black-500">NU Sci</h3>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-6">
+            {/* Logo */}
+            <div className="flex-shrink-0">
+              <Image src="/logo.png" alt="NU Sci Magazine" width="w-10" ratio={1}/>
+            </div>
+
+            {/* Social media icons */}
+            <div className="flex items-center space-x-6">
+              {socialLinks.map((social) => (
+                <Link
+                  key={social.label}
+                  href={social.href}
+                  newWindow={true}
+                  className="group"
+                >
+                  {social.icon}
+                  <span className="sr-only">{social.label}</span>
+                </Link>
+              ))}
+            </div>
           </div>
 
-          {/* The social media section */}
-          <div className="flex space-x-6">
-            {socialLinks.map((social) => (
-              <Link
-                key={social.label}
-                href={social.href}
-                newWindow={true}
-                className="group"
-              >
-                {social.icon}
-                <span className="sr-only">{social.label}</span>
-              </Link>
-            ))}
-          </div>
-
-          {/* The copyright section */}
-          <div className="text-center space-y-2">
-            <p className="text-sm text-black-400">
-              © {currentYear} NU Sci. All rights reserved.
-            </p>
-            <p className="text-sm text-black-400">
-              This website is built and maintained by the NU Sci web and software team.
-            </p>
+          {/* Copyright section */}
+          <div className="text-sm text-black-400 text-center md:text-right">
+            Built and maintained by the NU Sci web team.
           </div>
         </div>
       </div>
-    </footer>
   );
 };
 

--- a/src/design-system/components/Footer/Footer.tsx
+++ b/src/design-system/components/Footer/Footer.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Link from '@/primitives/Link';
+import Icon from '@/primitives/Icon';
+
+export interface FooterProps {
+  className?: string;
+}
+
+const Footer: React.FC<FooterProps> = ({ className = '' }) => {
+  const currentYear = new Date().getFullYear();
+
+  const socialLinks = [
+    {
+      label: 'Instagram',
+      href: 'https://www.instagram.com/nuscimag/',
+      icon: <Icon icon="instagram" size="md" className="text-black-400 group-hover:text-black-500 transition-colors duration-200" />,
+    },
+    {
+      label: 'LinkedIn',
+      href: 'https://www.linkedin.com/company/nu-sci-magazine/',
+      icon: <Icon icon="linkedin" size="md" className="text-black-400 group-hover:text-black-500 transition-colors duration-200" />,
+    },
+    {
+      label: 'Email',
+      href: 'mailto:northeasternsciencemagazine@gmail.com',
+      icon: <Icon icon="email" size="md" className="text-black-400 group-hover:text-black-500 transition-colors duration-200" />,
+    },
+  ];
+
+  return (
+    <footer className={`bg-black-900 text-black ${className}`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="flex flex-col items-center space-y-8">
+          {/* NU Sci Logo */}
+          <div className="text-center">
+            <h3 className="text-4xl font-bold text-black-500">NU Sci</h3>
+          </div>
+
+          {/* Social Links */}
+          <div className="flex space-x-6">
+            {socialLinks.map((social) => (
+              <Link
+                key={social.label}
+                href={social.href}
+                newWindow={true}
+                className="group"
+              >
+                {social.icon}
+                <span className="sr-only">{social.label}</span>
+              </Link>
+            ))}
+          </div>
+
+          {/* Copyright */}
+          <div className="text-center space-y-2">
+            <p className="text-sm text-black-400">
+              © {currentYear} NU Sci. All rights reserved.
+            </p>
+            <p className="text-sm text-black-400">
+              This website is built and maintained by the NU Sci web and software team
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/design-system/primitives/Icon/Icon.stories.tsx
+++ b/src/design-system/primitives/Icon/Icon.stories.tsx
@@ -38,6 +38,7 @@ const icons: IconProps["icon"][] = [
   "trash",
   "zoomin",
   "zoomout",
+  "email",
 ];
 
 const meta: Meta<typeof Icon> = {

--- a/src/design-system/primitives/Icon/variants.ts
+++ b/src/design-system/primitives/Icon/variants.ts
@@ -14,6 +14,7 @@ import {
   Trash2,
   ZoomIn,
   ZoomOut,
+  Mail
 } from "lucide-react";
 import { InstagramLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
 
@@ -73,6 +74,7 @@ export const iconMap = {
   trash: Trash2,
   zoomin: ZoomIn,
   zoomout: ZoomOut,
+  email: Mail,
 };
 
 export type IconName = keyof typeof iconMap;


### PR DESCRIPTION
## Front End Pull Request

### Brief Summary
Implements a footer that can be added to any page at the bottom. The footer contains logos of Instagram, LinkedIn, and a Email which lead to the corresponding pages when the logo is clicked on. The size of the footer changes depending on the screen size, and the color of all of the text and logos are black to keep it clean.


### Questions / Considerations for the Future
Change the email link to the actual NU Sci email.

### Image of changes
<img width="1178" height="487" alt="Screenshot 2025-10-01 192356" src="https://github.com/user-attachments/assets/751d17e2-7cc0-4c98-ae74-476a40cc65d4" />


[comment]: <> (Put the ticket # this PR closes.)
Closes #50 
